### PR TITLE
fix auto-publish-action

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
             toolchain: nightly-2022-11-21
             override: true
-      - run: cargo publish --token ${CRATES_TOKEN}
+      - run: cargo install cargo-workspaces
+      - run: cargo ws publish --from-git --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,14 @@ keywords = ["substrace", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
 build = "build.rs"
 edition = "2021"
-publish = false
+publish = true
 default-run = "cargo-substrace"
+
+[workspace]
+members = [
+    "substrace_lints",
+    "substrace_utils"
+]
 
 [[bin]]
 name = "cargo-substrace"

--- a/substrace_utils/Cargo.toml
+++ b/substrace_utils/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "substrace_utils"
-version = "0.1.65"
+version = "0.2.0"
 edition = "2021"
-publish = false
+publish = true
+description = "substrace_utils"
+license = "MIT"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }

--- a/substrace_utils/Cargo.toml
+++ b/substrace_utils/Cargo.toml
@@ -3,7 +3,7 @@ name = "substrace_utils"
 version = "0.2.0"
 edition = "2021"
 publish = true
-description = "substrace_utils"
+description = "Utility subcrate for substrace"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
`cargo publish` didn't work because we have subcrates. We now use `cargo-workspaces` crate for publishing and created a workspace.