### PR TITLE
Include version for substrace_utils dependency

### DIFF
--- a/substrace_lints/Cargo.toml
+++ b/substrace_lints/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 cargo_metadata = "0.14"
-substrace_utils = { path = "../substrace_utils" }
+substrace_utils = { path = "../substrace_utils", version="0.2.0" }
 enumset = "1.0.8"
 if_chain = "1.0"
 itertools = "0.10.1"


### PR DESCRIPTION
cargo publish complaining about missing version, which is now added.