### PR TITLE
Clippy cleanup

### DIFF
--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,9 +1,3 @@
-macro_rules! include_lint {
-    ($file_name: expr) => {
-        include_str!($file_name)
-    };
-}
-
 macro_rules! docs {
     ($($lint_name: expr,)*) => {
         pub fn explain(lint: &str) {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -111,7 +111,6 @@ impl rustc_driver::Callbacks for SubstraceCallbacks {
 
             let conf = substrace_lints::read_conf(sess);
             substrace_lints::register_plugins(lint_store, sess, &conf);
-            substrace_lints::register_pre_expansion_lints(lint_store, sess, &conf);
         }));
 
         // FIXME: #4825; This is required, because Substrace lints that are based on MIR have to be

--- a/substrace_lints/src/lib.rs
+++ b/substrace_lints/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(drain_filter)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
-#![feature(let_else)]
 #![feature(lint_reasons)]
 #![feature(never_type)]
 #![feature(once_cell)]
@@ -36,9 +35,6 @@ extern crate rustc_span;
 #[macro_use]
 extern crate substrace_utils;
 
-use rustc_data_structures::fx::FxHashSet;
-use rustc_lint::LintId;
-use rustc_semver::RustcVersion;
 use rustc_session::Session;
 
 /// Macro used to declare a Substrace lint.
@@ -164,18 +160,6 @@ use substrace_lints::{
 pub use crate::utils::conf::Conf;
 use crate::utils::conf::{format_error, TryConf};
 
-/// Register all pre expansion lints
-///
-/// Pre-expansion lints run before any macro expansion has happened.
-///
-/// Note that due to the architecture of the compiler, currently `cfg_attr` attributes on crate
-/// level (i.e `#![cfg_attr(...)]`) will still be expanded even when using a pre-expansion pass.
-///
-/// Used in `./src/driver.rs`.
-pub fn register_pre_expansion_lints(store: &mut rustc_lint::LintStore, sess: &Session, conf: &Conf) {
-
-}
-
 #[doc(hidden)]
 pub fn read_conf(sess: &Session) -> Conf {
     let file_name = match utils::conf::lookup_conf_file() {
@@ -191,7 +175,7 @@ pub fn read_conf(sess: &Session) -> Conf {
     let TryConf { conf, errors, warnings } = utils::conf::read(&file_name);
     // all conf errors are non-fatal, we just use the default conf in case of error
     for error in errors {
-        sess.err(&format!(
+        sess.err(format!(
             "error reading Substrace's configuration file `{}`: {}",
             file_name.display(),
             format_error(error)
@@ -213,7 +197,7 @@ pub fn read_conf(sess: &Session) -> Conf {
 /// Register all lints and lint groups with the rustc plugin registry
 ///
 /// Used in `./src/driver.rs`.
-pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf: &Conf) {
+pub fn register_plugins(store: &mut rustc_lint::LintStore, _: &Session, _: &Conf) {
 
     // Allows to enable or disable lints in code
     store.register_lints(&[no_panics::PANICS]);

--- a/substrace_lints/src/substrace_lints/auxiliary/paths.rs
+++ b/substrace_lints/src/substrace_lints/auxiliary/paths.rs
@@ -3,7 +3,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_lint::LateContext;
 
-pub fn is_insecure_hash_function<'hir>(cx: &LateContext<'hir>, generics: &hir::GenericArgs) -> bool {
+pub fn is_insecure_hash_function<'hir>(cx: &LateContext<'hir>, generics: &hir::GenericArgs<'_>) -> bool {
     for typ in generics.args {
         if let hir::GenericArg::Type(ty) = typ {
             if let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = &ty.kind {
@@ -27,40 +27,6 @@ pub fn is_like_storage_map(cx: &LateContext<'_>, fn_def_id: DefId) -> bool {
         || match_def_path(cx, fn_def_id, &STORAGE_N_MAP)
 }
 
-pub fn is_storage_map(cx: &LateContext<'_>, fn_def_id: DefId) -> bool {
-    match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_ITER)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_DRAIN)
-}
-
-pub fn is_storage_double_map(cx: &LateContext<'_>, fn_def_id: DefId) -> bool {
-    match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_ITER_PREFIX)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_DRAIN_PREFIX)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_ITER)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_DRAIN)
-}
-
-pub fn modifies_storage_double_map(cx: &LateContext<'_>, fn_def_id: DefId) -> bool {
-    match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_SWAP)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_TAKE)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_INSERT)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_REMOVE)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_REMOVE_PREFIX)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_TRY_MUTATE)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_MUTATE)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_TRY_MUTATE_EXISTS)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_DOUBLE_MAP_APPEND)
-}
-
-pub fn modifies_storage_map(cx: &LateContext<'_>, fn_def_id: DefId) -> bool {
-    match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_SWAP)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_REMOVE)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_TAKE)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_APPEND)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_INSERT)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_MIGRATE_KEY)
-        || match_def_path(cx, fn_def_id, &ITERABLE_STORAGE_MAP_MIGRATE_KEY_FROM_BLAKE)
-}
-
 pub const STORAGE_MAP: [&str; 5] = ["frame_support", "storage", "types", "map", "StorageMap"];
 pub const STORAGE_DOUBLE_MAP: [&str; 5] = ["frame_support", "storage", "types", "double_map", "StorageDoubleMap"];
 pub const STORAGE_N_MAP: [&str; 5] = ["frame_support", "storage", "types", "nmap", "StorageNMap"];
@@ -70,36 +36,5 @@ pub const TWOX128: [&str; 3] = ["frame_support", "hash", "Twox128"];
 pub const TWOX256: [&str; 3] = ["frame_support", "hash", "Twox256"];
 
 pub const IDENTITY: [&str; 3] = ["frame_support", "hash", "Identity"];
-
-pub const ITERABLE_STORAGE_MAP_ITER: [&str; 4] = ["frame_support", "storage", "IterableStorageMap", "iter"];
-pub const ITERABLE_STORAGE_MAP_DRAIN: [&str; 4] = ["frame_support", "storage", "IterableStorageMap", "drain"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_ITER_PREFIX: [&str; 4] =
-    ["frame_support", "storage", "IterableStorageDoubleMap", "iter_prefix"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_DRAIN_PREFIX: [&str; 4] =
-    ["frame_support", "storage", "IterableStorageDoubleMap", "drain_prefix"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_ITER: [&str; 4] =
-    ["frame_support", "storage", "IterableStorageDoubleMap", "iter"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_DRAIN: [&str; 4] =
-    ["frame_support", "storage", "IterableStorageDoubleMap", "drain"];
-pub const ITERABLE_STORAGE_MAP_INSERT: [&str; 4] = ["frame_support", "storage", "StorageMap", "insert"];
-pub const ITERABLE_STORAGE_MAP_SWAP: [&str; 4] = ["frame_support", "storage", "StorageMap", "swap"];
-pub const ITERABLE_STORAGE_MAP_REMOVE: [&str; 4] = ["frame_support", "storage", "StorageMap", "remove"];
-pub const ITERABLE_STORAGE_MAP_TAKE: [&str; 4] = ["frame_support", "storage", "StorageMap", "take"];
-pub const ITERABLE_STORAGE_MAP_APPEND: [&str; 4] = ["frame_support", "storage", "StorageMap", "append"];
-pub const ITERABLE_STORAGE_MAP_MIGRATE_KEY: [&str; 4] = ["frame_support", "storage", "StorageMap", "migrate_key"];
-pub const ITERABLE_STORAGE_MAP_MIGRATE_KEY_FROM_BLAKE: [&str; 4] =
-    ["frame_support", "storage", "StorageMap", "migrate_key_from_blake"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_SWAP: [&str; 4] = ["frame_support", "storage", "StorageDoubleMap", "swap"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_TAKE: [&str; 4] = ["frame_support", "storage", "StorageDoubleMap", "take"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_INSERT: [&str; 4] = ["frame_support", "storage", "StorageDoubleMap", "insert"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_REMOVE: [&str; 4] = ["frame_support", "storage", "StorageDoubleMap", "remove"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_REMOVE_PREFIX: [&str; 4] =
-    ["frame_support", "storage", "StorageDoubleMap", "remove_prefix"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_MUTATE: [&str; 4] = ["frame_support", "storage", "StorageDoubleMap", "mutate"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_APPEND: [&str; 4] = ["frame_support", "storage", "StorageDoubleMap", "append"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_TRY_MUTATE: [&str; 4] =
-    ["frame_support", "storage", "StorageDoubleMap", "try_mutate"];
-pub const ITERABLE_STORAGE_DOUBLE_MAP_TRY_MUTATE_EXISTS: [&str; 4] =
-    ["frame_support", "storage", "StorageDoubleMap", "try_mutate_exists"];
 
 pub const WITH_TRANSACTION: [&str; 4] = ["frame_support", "storage", "transactional", "with_transaction"];

--- a/substrace_lints/src/substrace_lints/extrinsics_must_be_tagged.rs
+++ b/substrace_lints/src/substrace_lints/extrinsics_must_be_tagged.rs
@@ -1,20 +1,12 @@
-use super::auxiliary::paths;
-use substrace_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
-use substrace_utils::source::{first_line_of_span, snippet_opt, line_span, span_extend_prev_str};
-use substrace_utils::match_def_path;
-use itertools::Itertools;
-use rustc_ast::ast::{AttrKind, Attribute};
+use substrace_utils::diagnostics::span_lint_and_sugg;
+use substrace_utils::source::{snippet_opt, line_span, span_extend_prev_str};
 use rustc_ast::AstDeref;
 use rustc_ast::ast as ast;
-use rustc_ast::token::CommentKind;
-use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint, impl_lint_pass};
-use rustc_span::source_map::{BytePos, Span, SourceMap, original_sp};
-use rustc_span::{sym, Pos, DUMMY_SP};
-use std::ops::Range;
+use rustc_span::source_map::Span;
 
 declare_lint! {
     pub EXTRINSICS_MUST_BE_TAGGED,
@@ -27,28 +19,22 @@ impl_lint_pass!(ExtrinsicsMustBeTagged => [EXTRINSICS_MUST_BE_TAGGED]);
 #[derive(Clone, Default)]
 pub struct ExtrinsicsMustBeTagged;
 
-impl ExtrinsicsMustBeTagged {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 // TODO: Check pallet::call_index is not in a comment? Relevant if it is 0?! But not a good idea to implement now, since we're most likely not gonna keep using this tacting of checking plain text.
 impl<'tcx> LateLintPass<'tcx> for ExtrinsicsMustBeTagged {
     fn check_fn(&mut self,
                 cx: &LateContext<'tcx>,
-                fn_kind: hir::intravisit::FnKind<'tcx>, //TODO: We don't use the last 4 arguments. Replace with _
-                fn_decl: &'tcx hir::FnDecl<'tcx>,
-                fn_body: &'tcx hir::Body<'tcx>,
-                span: Span,
-                hir_id: hir::hir_id::HirId) {
+                fn_kind: hir::intravisit::FnKind<'tcx>, 
+                _: &'tcx hir::FnDecl<'tcx>,
+                _: &'tcx hir::Body<'tcx>,
+                _: Span,
+                _: hir::hir_id::HirId) {
         if let hir::intravisit::FnKind::Method(rustc_span::symbol::Ident {name, ..}, fn_sig) = fn_kind 
             && is_extrinsic_name(name, cx)
             && let index = get_index_in_expansion(name, cx)
             && !get_index_in_macro(cx, fn_sig).is_some_and(|i| i == index) {
 
             let fn_sig_span_line = snippet_opt(cx, line_span(cx, fn_sig.span)); // also extend to include whitespace
-            let suggestion = format!("#[pallet::call_index({})]\n{}", index, fn_sig_span_line.unwrap()); // We should always be able to find the span. If we cannot, there is a bug in this code, so panic and bug report.
+            let suggestion = format!("#[pallet::call_index({})]\n{}", index, fn_sig_span_line.expect("We should always be able to find the span.")); 
 
             span_lint_and_sugg(
                 cx,
@@ -72,25 +58,25 @@ pub fn get_index_in_macro<'tcx>(cx: &LateContext<'tcx>, fn_sig: &hir::FnSig<'tcx
 }
 
 // Gets call index for extrinsic from code expanded by pallet::call macro
-pub fn get_index_in_expansion<'tcx>(func_name_symbol: rustc_span::symbol::Symbol, cx: &LateContext<'tcx>) -> u8 {
-    for item_id_ in cx.tcx.hir().root_module().item_ids.into_iter() { // Gets entire file
+pub fn get_index_in_expansion(func_name_symbol: rustc_span::symbol::Symbol, cx: &LateContext<'_>) -> u8 {
+    for item_id_ in cx.tcx.hir().root_module().item_ids.iter() { // Gets entire file
         if let Some(hir::Node::Item(parent_node)) = cx.tcx.hir().find(item_id_.hir_id())
         && let hir::ItemKind::Mod(mod_item) = parent_node.kind { //pallet module
 
-            for mod_item_id in mod_item.item_ids.into_iter() {
+            for mod_item_id in mod_item.item_ids.iter() {
                 let node_in_mod = cx.tcx.hir().find(mod_item_id.hir_id());
 
                 if let Some(hir::Node::Item(item_in_mod)) = node_in_mod
                     && let hir::ItemKind::Enum(hir::EnumDef{variants}, _) = &item_in_mod.kind { // Look for implement blocks
 
-                    for variant in variants.into_iter() {
+                    for variant in variants.iter() {
                         if variant.ident.name == func_name_symbol {
                                 
-                            for attrib in cx.tcx.hir().attrs(variant.hir_id).into_iter() {
-                                if let ast::AttrKind::Normal(normalAttrib) = &attrib.kind
-                                    && let ast::NormalAttr{item, ..} = normalAttrib.ast_deref()
+                            for attrib in cx.tcx.hir().attrs(variant.hir_id).iter() {
+                                if let ast::AttrKind::Normal(normal_attrib) = &attrib.kind
+                                    && let ast::NormalAttr{item, ..} = normal_attrib.ast_deref()
                                     && let Some(ast::MetaItemKind::List(list_items)) = item.meta_kind() 
-                                    && list_items.len() > 0 
+                                    && !list_items.is_empty() 
                                     && let ast::NestedMetaItem::MetaItem(meta_item) = &list_items[0]
                                     && let ast::MetaItemKind::NameValue(lit) = &meta_item.kind 
                                     && let ast::LitKind::Int(the_index_wow, _) = lit.kind {
@@ -110,18 +96,18 @@ pub fn get_index_in_expansion<'tcx>(func_name_symbol: rustc_span::symbol::Symbol
 
 // Check if func_name_symbol is in the list of functions created by pallet::call macro that are exposed as extrinsics
 // TODO: This is also used by missing_transactional. Should probably be moved to some other helper functions place?
-pub fn is_extrinsic_name<'tcx>(func_name_symbol: rustc_span::symbol::Symbol, cx: &LateContext<'tcx>) -> bool {
-    for item_id_ in cx.tcx.hir().root_module().item_ids.into_iter() { // Gets entire file
+pub fn is_extrinsic_name(func_name_symbol: rustc_span::symbol::Symbol, cx: &LateContext<'_>) -> bool {
+    for item_id_ in cx.tcx.hir().root_module().item_ids.iter() { // Gets entire file
         if let Some(hir::Node::Item(parent_node)) = cx.tcx.hir().find(item_id_.hir_id())
         && let hir::ItemKind::Mod(mod_item) = parent_node.kind { //pallet module
 
-            for mod_item_id in mod_item.item_ids.into_iter() {
+            for mod_item_id in mod_item.item_ids.iter() {
                 let node_in_mod = cx.tcx.hir().find(mod_item_id.hir_id());
 
                 if let Some(hir::Node::Item(item_in_mod)) = node_in_mod
                     && let hir::ItemKind::Impl(impl_block) = item_in_mod.kind { // Look for implement blocks
 
-                    for item_ref in impl_block.items.into_iter() {
+                    for item_ref in impl_block.items.iter() {
                         if item_ref.ident.as_str() == "get_call_names"
                             && let item_ref_hir_id = item_ref.id.hir_id()
                             && let item_ref_node = cx.tcx.hir().find(item_ref_hir_id)
@@ -134,7 +120,7 @@ pub fn is_extrinsic_name<'tcx>(func_name_symbol: rustc_span::symbol::Symbol, cx:
                             && let hir::ExprKind::AddrOf(_, _, ref_expr) = block_expr.kind
                             && let hir::ExprKind::Array(extrinsic_name_exprs) = ref_expr.kind {
 
-                            for extrinsic_name_expr in extrinsic_name_exprs.into_iter() { // Check for each extrinsic whether func_name_symbol is in it
+                            for extrinsic_name_expr in extrinsic_name_exprs.iter() { // Check for each extrinsic whether func_name_symbol is in it
                                 if let hir::ExprKind::Lit(spanned) = &extrinsic_name_expr.kind
                                     && let rustc_ast::ast::LitKind::Str(extrinsic_symbol, _) = spanned.node
                                     && func_name_symbol == extrinsic_symbol { 

--- a/substrace_lints/src/substrace_lints/missing_security_doc.rs
+++ b/substrace_lints/src/substrace_lints/missing_security_doc.rs
@@ -3,9 +3,9 @@ use substrace_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use substrace_utils::source::first_line_of_span;
 use itertools::Itertools;
 use rustc_ast::ast::Attribute;
+use rustc_errors::Applicability;
 use rustc_ast::token::CommentKind;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint, impl_lint_pass};
@@ -29,13 +29,14 @@ impl<'tcx> LateLintPass<'tcx> for DocMarkdown {
         if let hir::ItemKind::TyAlias(ty, ..) = item.kind
             && let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = ty.kind
             && let hir::def::Res::Def(_, id) = path.res
-            && if paths::is_like_storage_map(cx, id)
-            && let attrs = cx.tcx.hir().attrs(item.hir_id())
-            && let headers = check_attrs(cx, &Default::default(), attrs) {
+            && paths::is_like_storage_map(cx, id) {
+            
+            let attrs = cx.tcx.hir().attrs(item.hir_id());
+            let headers = check_attrs(cx, &Default::default(), attrs);
 
             for segment in path.segments {
                 if let Some(args) = segment.args
-                    && if paths::is_insecure_hash_function(cx, args) && !headers.security {
+                    && paths::is_insecure_hash_function(cx, args) && !headers.security {
                     
                     span_lint_and_sugg(
                         cx,

--- a/substrace_lints/src/substrace_lints/missing_security_doc.rs
+++ b/substrace_lints/src/substrace_lints/missing_security_doc.rs
@@ -45,7 +45,7 @@ impl<'tcx> LateLintPass<'tcx> for DocMarkdown {
                         "substrace: Twox{64, 128, 256} and Identity are at not secure!",
                         "use Blake2, or add a # Security doc comment describing why the usage is correct",
                         "/// # Security
-    /// Twox64Concat is safe because the ..."
+/// Twox64Concat is safe because the ..."
                             .to_string(),
                         Applicability::HasPlaceholders,
                     );

--- a/substrace_lints/src/substrace_lints/missing_security_doc.rs
+++ b/substrace_lints/src/substrace_lints/missing_security_doc.rs
@@ -2,7 +2,7 @@ use super::auxiliary::paths;
 use substrace_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use substrace_utils::source::first_line_of_span;
 use itertools::Itertools;
-use rustc_ast::ast::{AttrKind, Attribute};
+use rustc_ast::ast::Attribute;
 use rustc_ast::token::CommentKind;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
@@ -23,12 +23,6 @@ impl_lint_pass!(DocMarkdown => [MISSING_SECURITY_DOC]);
 
 #[derive(Clone, Default)]
 pub struct DocMarkdown;
-
-impl DocMarkdown {
-    pub fn new() -> Self {
-        Self
-    }
-}
 
 impl<'tcx> LateLintPass<'tcx> for DocMarkdown {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
@@ -135,7 +129,7 @@ fn check_attrs<'a>(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs
 
     for attr in attrs {
         if let Some((comment, comment_kind)) = attr.doc_str_and_comment_kind() {
-            let (comment, current_spans) = strip_doc_comment_decoration(&comment.as_str(), comment_kind, attr.span);
+            let (comment, current_spans) = strip_doc_comment_decoration(comment.as_str(), comment_kind, attr.span);
             spans.extend_from_slice(&current_spans);
             doc.push_str(&comment);
         } else if attr.has_name(sym::doc) {

--- a/substrace_lints/src/substrace_lints/missing_transactional.rs
+++ b/substrace_lints/src/substrace_lints/missing_transactional.rs
@@ -1,20 +1,12 @@
 use super::auxiliary::paths;
-use substrace_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
-use substrace_utils::source::{first_line_of_span, snippet_opt, line_span, span_extend_prev_str};
+use substrace_utils::diagnostics::span_lint_and_sugg;
+use substrace_utils::source::{snippet_opt, line_span};
 use substrace_utils::match_def_path;
-use itertools::Itertools;
-use rustc_ast::ast::{AttrKind, Attribute};
-use rustc_ast::AstDeref;
-use rustc_ast::ast as ast;
-use rustc_ast::token::CommentKind;
-use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint, impl_lint_pass};
-use rustc_span::source_map::{BytePos, Span, SourceMap, original_sp};
-use rustc_span::{sym, Pos, DUMMY_SP};
-use std::ops::Range;
+use rustc_span::source_map::Span;
 
 use super::extrinsics_must_be_tagged::is_extrinsic_name;
 
@@ -29,21 +21,15 @@ impl_lint_pass!(MissingTransactional => [MISSING_TRANSACTIONAL]);
 #[derive(Clone, Default)]
 pub struct MissingTransactional;
 
-impl MissingTransactional {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 // Check if extrinsics use with_transaction
 impl<'tcx> LateLintPass<'tcx> for MissingTransactional {
     fn check_fn(&mut self,
         cx: &LateContext<'tcx>,
         fn_kind: hir::intravisit::FnKind<'tcx>,
-        fn_decl: &'tcx hir::FnDecl<'tcx>,
+        _: &'tcx hir::FnDecl<'tcx>,
         fn_body: &'tcx hir::Body<'tcx>,
-        span: Span,
-        hir_id: hir::hir_id::HirId) {
+        _: Span,
+        _: hir::hir_id::HirId) {
         if let hir::intravisit::FnKind::Method(rustc_span::symbol::Ident {name, ..}, fn_sig) = fn_kind 
             && is_extrinsic_name(name, cx) {
 

--- a/substrace_lints/src/substrace_lints/no_panics.rs
+++ b/substrace_lints/src/substrace_lints/no_panics.rs
@@ -7,7 +7,7 @@ use substrace_utils::source::snippet_opt;
 
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint, impl_lint_pass};
-use rustc_span::{hygiene::SyntaxContext, symbol::sym, BytePos, Span};
+use rustc_span::{hygiene::SyntaxContext, BytePos, Span};
 use std::str::FromStr;
 
 declare_lint! {
@@ -82,7 +82,7 @@ impl<'hir> LateLintPass<'hir> for Panics {
     fn check_attribute(&mut self, _: &LateContext<'_>, attr: &ast::Attribute) {
         if let Some(items) = &attr.meta_item_list() {
             if let Some(ident) = attr.ident() {
-                let ident = &*ident.as_str();
+                let ident = ident.as_str();
                 if matches!(ident, "warn" | "deny" | "forbid") {
                     items.iter().for_each(|item| {
                         if let Some(attr1) = extract_clippy_lint(item) {
@@ -126,7 +126,7 @@ fn extract_clippy_lint(lint: &NestedMetaItem) -> Option<RequiredAttributes> {
         if tool_name.name.as_str() == "clippy";
         let lint_name = meta_item.path.segments.last().unwrap().ident.name;
         then {
-            return RequiredAttributes::from_str(&lint_name.as_str()).ok();
+            return RequiredAttributes::from_str(lint_name.as_str()).ok();
         }
     }
     None

--- a/substrace_utils/src/paths.rs
+++ b/substrace_utils/src/paths.rs
@@ -36,9 +36,7 @@ pub const F32_EPSILON: [&str; 4] = ["core", "f32", "<impl f32>", "EPSILON"];
 pub const F64_EPSILON: [&str; 4] = ["core", "f64", "<impl f64>", "EPSILON"];
 pub const FROM_ITERATOR_METHOD: [&str; 6] = ["core", "iter", "traits", "collect", "FromIterator", "from_iter"];
 pub const FROM_STR_METHOD: [&str; 5] = ["core", "str", "traits", "FromStr", "from_str"];
-#[expect(clippy::invalid_paths)] // internal lints do not know about all external crates
 pub const FUTURES_IO_ASYNCREADEXT: [&str; 3] = ["futures_util", "io", "AsyncReadExt"];
-#[expect(clippy::invalid_paths)] // internal lints do not know about all external crates
 pub const FUTURES_IO_ASYNCWRITEEXT: [&str; 3] = ["futures_util", "io", "AsyncWriteExt"];
 pub const HASHMAP_CONTAINS_KEY: [&str; 6] = ["std", "collections", "hash", "map", "HashMap", "contains_key"];
 pub const HASHMAP_INSERT: [&str; 6] = ["std", "collections", "hash", "map", "HashMap", "insert"];
@@ -142,9 +140,7 @@ pub const SYM_MODULE: [&str; 3] = ["rustc_span", "symbol", "sym"];
 pub const SYNTAX_CONTEXT: [&str; 3] = ["rustc_span", "hygiene", "SyntaxContext"];
 pub const TO_OWNED_METHOD: [&str; 4] = ["alloc", "borrow", "ToOwned", "to_owned"];
 pub const TO_STRING_METHOD: [&str; 4] = ["alloc", "string", "ToString", "to_string"];
-#[expect(clippy::invalid_paths)] // internal lints do not know about all external crates
 pub const TOKIO_IO_ASYNCREADEXT: [&str; 5] = ["tokio", "io", "util", "async_read_ext", "AsyncReadExt"];
-#[expect(clippy::invalid_paths)] // internal lints do not know about all external crates
 pub const TOKIO_IO_ASYNCWRITEEXT: [&str; 5] = ["tokio", "io", "util", "async_write_ext", "AsyncWriteExt"];
 pub const TRY_FROM: [&str; 4] = ["core", "convert", "TryFrom", "try_from"];
 pub const VEC_AS_MUT_SLICE: [&str; 4] = ["alloc", "vec", "Vec", "as_mut_slice"];

--- a/substrace_utils/src/source.rs
+++ b/substrace_utils/src/source.rs
@@ -91,23 +91,21 @@ fn span_extend_prev_str_internal(
     //           ^^^^ returned span without the check
     //     ---------- correct span
     let prev_source = source_map.span_to_prev_source(sp).ok()?;
-    for ws in &[" ", "\t", "\n"] {
-        let pat = pat.to_owned();
-        if let Some(pat_pos) = prev_source.rfind(&pat) {
-            let just_after_pat_pos = pat_pos + pat.len() - 1;
-            let just_after_pat_plus_ws = if include_whitespace {
-                just_after_pat_pos
-                    + prev_source[just_after_pat_pos..]
-                        .find(|c: char| !c.is_whitespace())
-                        .unwrap_or(0)
-            } else {
-                just_after_pat_pos
-            };
-            let len = prev_source.len() - just_after_pat_plus_ws;
-            let prev_source = &prev_source[just_after_pat_plus_ws..];
-            if accept_newlines || !prev_source.trim_start().contains('\n') {
-                return Some(sp.with_lo(BytePos(sp.lo().0 - len as u32)));
-            }
+    let pat = pat.to_owned();
+    if let Some(pat_pos) = prev_source.rfind(&pat) {
+        let just_after_pat_pos = pat_pos + pat.len() - 1;
+        let just_after_pat_plus_ws = if include_whitespace {
+            just_after_pat_pos
+                + prev_source[just_after_pat_pos..]
+                    .find(|c: char| !c.is_whitespace())
+                    .unwrap_or(0)
+        } else {
+            just_after_pat_pos
+        };
+        let len = prev_source.len() - just_after_pat_plus_ws;
+        let prev_source = &prev_source[just_after_pat_plus_ws..];
+        if accept_newlines || !prev_source.trim_start().contains('\n') {
+            return Some(sp.with_lo(BytePos(sp.lo().0 - len as u32)));
         }
     }
 


### PR DESCRIPTION
Clean up code to remove most clippy warnings so that output is not spammed anymore.
Remove unused functions and paths: hard to maintain. Can be added again once required.